### PR TITLE
Return `error` for `gmsk.NewError`.

### DIFF
--- a/error.go
+++ b/error.go
@@ -14,7 +14,8 @@ type MskError struct {
 var _ error = (*MskError)(nil)
 
 // NewError creates an error from [res.Code]. The returned error will be nil for [res.OK].
-func NewError(code res.Code) *MskError {
+// The underlying type of the error is a [MskError].
+func NewError(code res.Code) error {
 	if code.IsOk() {
 		return nil
 	}


### PR DESCRIPTION
When converting a `nil` `gmsk.MskError` to `error`, it will actually not be `nil`. This will fix that errenous behavior.